### PR TITLE
add octavia to tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "tempest",
     "pydantic",
     "manila-tempest-plugin",
+    "octavia-tempest-plugin",
     "zun-tempest-plugin",
     "blazar-tempest-plugin @ git+https://github.com/chameleoncloud/chi-blazar-tempest-plugin"
 ]

--- a/reference_configs/kvm_prod/include_list
+++ b/reference_configs/kvm_prod/include_list
@@ -1,2 +1,1 @@
-smoke
 octavia

--- a/reference_configs/kvm_prod/include_list
+++ b/reference_configs/kvm_prod/include_list
@@ -1,1 +1,2 @@
 smoke
+octavia

--- a/reference_configs/kvm_prod/tempest.conf
+++ b/reference_configs/kvm_prod/tempest.conf
@@ -53,6 +53,12 @@ api_extensions = subnetpool-prefix-ops,default-subnetpools,availability_zone,net
 # Allow the execution of IPv6 tests. (boolean value)
 ipv6 = false
 
+[load_balancer]
+# Type of RBAC tests to run. “advanced” runs the octavia default RBAC tests. 
+# “owner_or_admin” runs the legacy owner or admin tests. 
+# “keystone_default_roles” runs the tests using only the keystone default roles. 
+# “none” disables the RBAC tests.
+RBAC_test_type = none
 
 [dashboard]
 dashboard_url = https://kvm.tacc.chameleoncloud.org


### PR DESCRIPTION
edit: this needs more work in order to run tests as non-admin, builtin octavia tempest tests all need admin creds.