### PR TITLE
UC: enable test for glance protection properties

### DIFF
--- a/reference_configs/uc_prod/tempest.conf
+++ b/reference_configs/uc_prod/tempest.conf
@@ -49,6 +49,8 @@ shelve = false
 # running instances? (boolean value)
 snapshot = false
 
+[image]
+image_protected_properties = "chameleon-supported"
 
 [network]
 public_network_id = "44b38c44-2a42-4b6d-b129-6c8f1b2a1375"


### PR DESCRIPTION
As we haven't deployed the feature at CHI@UC yet, test correctly shows a failure:

```
Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):
      File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/blazar_tempest_plugin/tests/api/test_chi_protected_images.py", line 64, in test_set_get_protected_property
    self.assertRaises(
    ~~~~~~~~~~~~~~~~~^
        lib_exc.Forbidden,
        ^^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        [{"add": f"/{protected_property}", "value": "true"}],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
      File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/testtools/testcase.py", line 495, in assertRaises
    self.assertThat(our_callable, matcher)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
      File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/testtools/testcase.py", line 509, in assertThat
    raise mismatch_error
    testtools.matchers._impl.MismatchError: <bound method ImagesClient.update_image of <tempest.lib.services.image.v2.images_client.ImagesClient object at 0x7fb119217650>> returned {'foo': 'bar', 'chameleon-supported': 'true', 'name': 'tempest-image-2040816592', 'disk_format': 'raw', 'container_format': 'bare', 'visibility': 'private', 'size': None, 'virtual_size': None, 'status': 'queued', 'checksum': None, 'protected': False, 'min_ram': 0, 'min_disk': 0, 'owner': '5056818270a8405aa5c776420d53c791', 'os_hidden': False, 'os_hash_algo': None, 'os_hash_value': None, 'id': 'd3d578b8-2732-41ec-8d01-50adeaae64ed', 'created_at': '2025-04-22T22:09:07Z', 'updated_at': '2025-04-22T22:09:08Z', 'tags': [], 'self': '/v2/images/d3d578b8-2732-41ec-8d01-50adeaae64ed', 'file': '/v2/images/d3d578b8-2732-41ec-8d01-50adeaae64ed/file', 'schema': '/v2/schemas/image'}
```