### PR TITLE
Skip another openrc on KVM until we get it working

### DIFF
--- a/reference_configs/kvm_prod/tempest.conf
+++ b/reference_configs/kvm_prod/tempest.conf
@@ -50,7 +50,7 @@ catalog_type = volumev3
 # uncomment when the protected properties are enabled
 #image_protected_properties = "chameleon-supported"
 cc_image_tests_image_names = CC-Ubuntu22.04,CC-Ubuntu22.04-CUDA,CC-Ubuntu24.04,CC-Ubuntu24.04-CUDA,CC-CentOS9-Stream
-cc_image_tests_skip_test_regex = verify_rclone_and_object_store|verify_openrc
+cc_image_tests_skip_test_regex = verify_rclone_and_object_store|verify_openrc|verify_openrc_exists
 
 [network]
 # openstack network show public -f value -c id


### PR DESCRIPTION
This will get rid of a handful of failures in the nightly smoke tests at least for now until we have time to get openrc sorted on KVM.