### PR TITLE
disable rgw upload quota test

### DIFF
--- a/reference_configs/tacc_prod/exclude_list
+++ b/reference_configs/tacc_prod/exclude_list
@@ -7,5 +7,8 @@ tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON
 tempest.api.compute.servers.test_server_addresses.ServerAddressesTestJSON
 tempest.api.compute.servers.test_create_server.ServersTestManualDisk
 
+# known failing due to using RGW instead of swift implementation
+tempest.api.object_storage.test_container_quotas.ContainerQuotasTest.test_upload_too_many_objects
+
 # non-critical tests we don't want run by default (they run separately)
 non_critical

--- a/reference_configs/uc_prod/exclude_list
+++ b/reference_configs/uc_prod/exclude_list
@@ -7,5 +7,8 @@ tempest.api.compute.servers.test_server_actions.ServerActionsTestJSON
 tempest.api.compute.servers.test_server_addresses.ServerAddressesTestJSON
 tempest.api.compute.servers.test_create_server.ServersTestManualDisk
 
+# known failing due to using RGW instead of swift implementation
+tempest.api.object_storage.test_container_quotas.ContainerQuotasTest.test_upload_too_many_objects
+
 # non-critical tests we don't want run by default (they run separately)
 non_critical


### PR DESCRIPTION
the rgw upload quota test fails intermittently due to a race condition in how ceph rgw implements quota enforcement. The test was written for swift originally, and doesn't give us a good signal.