### PR TITLE
rework targeting of image tests

### DIFF
--- a/.github/workflows/test_chi_tacc_prod_images.yaml
+++ b/.github/workflows/test_chi_tacc_prod_images.yaml
@@ -17,13 +17,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  run_tests:
-    name: "CHI@TACC Smoke Tests (Non-Critical)"
+  critical_tests:
+    name: "CHI@TACC Image Tests"
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/tacc_prod/
       name: "CHI@TACC"
-      regex: ".*NONCRITICAL.*"
+      enable_alerts: true
+      regex: "blazar_tempest_plugin.tests.scenario.test_images.*(?<!non)critical"
+    secrets:
+      accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
+      slack_webhook_url: ${{secrets.slack_webhook_url}}
+  noncritical_tests:
+    name: "CHI@TACC Image Tests (Non-Critical)"
+    uses: ./.github/workflows/tempest_action.yaml
+    with:
+      config-path: reference_configs/tacc_prod/
+      name: "CHI@TACC"
+      enable_alerts: true
+      regex: "blazar_tempest_plugin.tests.scenario.test_images.*noncritical"
     secrets:
       accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
       slack_webhook_url: ${{secrets.slack_noncritical_webhook_url}}

--- a/.github/workflows/test_chi_uc_prod_images.yaml
+++ b/.github/workflows/test_chi_uc_prod_images.yaml
@@ -17,13 +17,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  run_tests:
+  critical_tests:
+    name: "CHI@UC Image Tests"
+    uses: ./.github/workflows/tempest_action.yaml
+    with:
+      config-path: reference_configs/uc_prod/
+      name: "CHI@UC"
+      enable_alerts: true
+      regex: "blazar_tempest_plugin.tests.scenario.test_images.*(?<!non)critical"
+    secrets:
+      accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
+      slack_webhook_url: ${{secrets.slack_webhook_url}}
+  noncritical_tests:
     name: "CHI@UC Smoke Tests (Non-Critical)"
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/uc_prod/
       name: "CHI@UC"
-      regex: ".*NONCRITICAL.*"
+      enable_alerts: true
+      regex: "blazar_tempest_plugin.tests.scenario.test_images.*noncritical"
     secrets:
       accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
       slack_webhook_url: ${{secrets.slack_noncritical_webhook_url}}

--- a/.github/workflows/test_kvm_tacc_prod_images.yaml
+++ b/.github/workflows/test_kvm_tacc_prod_images.yaml
@@ -1,4 +1,4 @@
-name: run non-critical smoke tests for KVM@TACC
+name: run image smoke tests for KVM@TACC
 
 on:
   workflow_dispatch:
@@ -17,14 +17,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  run_tests:
-    name: "KVM@TACC Smoke Tests (Non-Critical)"
+  critical_tests:
+    name: "KVM@TACC Image Tests"
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/kvm_prod/
       name: "KVM@TACC"
       enable_alerts: true
-      regex: ".*NONCRITICAL.*"
+      regex: "blazar_tempest_plugin.tests.scenario.test_images.*(?<!non)critical"
+    secrets:
+      accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
+      slack_webhook_url: ${{secrets.slack_webhook_url}}
+  noncritical_tests:
+    name: "KVM@TACC Image Tests"
+    uses: ./.github/workflows/tempest_action.yaml
+    with:
+      config-path: reference_configs/kvm_prod/
+      name: "KVM@TACC"
+      enable_alerts: true
+      regex: "blazar_tempest_plugin.tests.scenario.test_images.*noncritical"
     secrets:
       accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
       slack_webhook_url: ${{secrets.slack_noncritical_webhook_url}}

--- a/reference_configs/kvm_prod/exclude_list
+++ b/reference_configs/kvm_prod/exclude_list
@@ -1,5 +1,2 @@
 # known failing due to interaction between federated auth and our horizon config
 tempest.scenario.test_dashboard_basic_ops.TestDashboardBasicOps.test_basic_scenario
-
-# non-critical tests we don't want run by default (they run separately)
-non_critical

--- a/reference_configs/tacc_prod/exclude_list
+++ b/reference_configs/tacc_prod/exclude_list
@@ -9,6 +9,3 @@ tempest.api.compute.servers.test_create_server.ServersTestManualDisk
 
 # known failing due to using RGW instead of swift implementation
 tempest.api.object_storage.test_container_quotas.ContainerQuotasTest.test_upload_too_many_objects
-
-# non-critical tests we don't want run by default (they run separately)
-non_critical

--- a/reference_configs/uc_prod/exclude_list
+++ b/reference_configs/uc_prod/exclude_list
@@ -9,6 +9,3 @@ tempest.api.compute.servers.test_create_server.ServersTestManualDisk
 
 # known failing due to using RGW instead of swift implementation
 tempest.api.object_storage.test_container_quotas.ContainerQuotasTest.test_upload_too_many_objects
-
-# non-critical tests we don't want run by default (they run separately)
-non_critical


### PR DESCRIPTION
We'll now have 3 "categories" of test:

Group 1 are all tests tagged with `smoke`, and not excluded. These ideally don't take a huge amount of time to run, and should reliably indicate problems.

Group 2 is all image tests
These take a long time to run, so we'd like scheduling flexibility.

Of these image tests, we want the ability to indicate which ones are important to alert on, and which ones not. for now, this is done by the "critical" and "noncritical" test attributes, giving two subgroups.