### PR TITLE
ensure all jobs referencing the same site obey concurrency

### DIFF
--- a/.github/workflows/tempest_action.yaml
+++ b/.github/workflows/tempest_action.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   run_tempest:
     concurrency:
-      group: ${{inputs.name}}
+      group: ${{inputs.config-path}}
       cancel-in-progress: false
     name: "Tempest Tests: ${{inputs.name}}"
     runs-on: ubuntu-22.04

--- a/.github/workflows/tempest_action.yaml
+++ b/.github/workflows/tempest_action.yaml
@@ -58,10 +58,16 @@ jobs:
       - name: List Tests that will be run
         working-directory: workspace
         run: |
-          tempest run \
-            --include-list etc/include_list \
-            --exclude-list etc/exclude_list \
-            --list-tests
+          if [[ -n "${{inputs.regex}}" ]]; then
+            tempest run \
+              --list-tests \
+              --regex "${{inputs.regex}}"
+          else
+            tempest run \
+              --list-tests \
+              --include-list etc/include_list \
+              --exclude-list etc/exclude_list
+          fi
       - name: Run Tests
         id: tempest_run_tests
         working-directory: workspace

--- a/.github/workflows/tempest_action.yaml
+++ b/.github/workflows/tempest_action.yaml
@@ -25,6 +25,9 @@ on:
 
 jobs:
   run_tempest:
+    concurrency:
+      group: ${{inputs.name}}
+      cancel-in-progress: false
     name: "Tempest Tests: ${{inputs.name}}"
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/test_chi_edge_prod.yaml
+++ b/.github/workflows/test_chi_edge_prod.yaml
@@ -12,10 +12,6 @@ on:
       - .github/workflows/tempest_action.yaml
       - .github/workflows/test_chi_edge_prod.yaml
 
-concurrency:
-  group: "CHI@Edge"
-  cancel-in-progress: false
-
 jobs:
   run_tests:
     name: "CHI@Edge Smoke Tests"

--- a/.github/workflows/test_chi_ncar_prod.yaml
+++ b/.github/workflows/test_chi_ncar_prod.yaml
@@ -12,10 +12,6 @@ on:
       - .github/workflows/tempest_action.yaml
       - .github/workflows/test_chi_ncar_prod.yaml
 
-concurrency:
-  group: "CHI@NCAR"
-  cancel-in-progress: false
-
 jobs:
   run_tests:
     name: "CHI@NCAR Smoke Tests"

--- a/.github/workflows/test_chi_nu_prod.yaml
+++ b/.github/workflows/test_chi_nu_prod.yaml
@@ -5,10 +5,6 @@ on:
   schedule:
     - cron: "20 7 * * *"
 
-concurrency:
-  group: "CHI@NU"
-  cancel-in-progress: false
-
 jobs:
   run_tests:
     name: "CHI@NU Smoke Tests"

--- a/.github/workflows/test_chi_tacc_prod.yaml
+++ b/.github/workflows/test_chi_tacc_prod.yaml
@@ -12,10 +12,6 @@ on:
       - .github/workflows/tempest_action.yaml
       - .github/workflows/test_chi_tacc_prod.yaml
 
-concurrency:
-  group: "CHI@TACC"
-  cancel-in-progress: false
-
 jobs:
   run_tests:
     name: "CHI@TACC Smoke Tests"

--- a/.github/workflows/test_chi_tacc_prod_images.yaml
+++ b/.github/workflows/test_chi_tacc_prod_images.yaml
@@ -1,4 +1,4 @@
-name: run non-critical smoke tests for CHI@TACC
+name: run image smoke tests for CHI@TACC
 
 on:
   workflow_dispatch:
@@ -11,10 +11,6 @@ on:
       - src
       - .github/workflows/tempest_action.yaml
       - .github/workflows/test_chi_tacc_prod_noncritical.yaml
-
-concurrency:
-  group: "CHI@TACC"
-  cancel-in-progress: false
 
 jobs:
   critical_tests:

--- a/.github/workflows/test_chi_tacc_prod_images.yaml
+++ b/.github/workflows/test_chi_tacc_prod_images.yaml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/tacc_prod/
-      name: "CHI@TACC"
+      name: "CHI@TACC-image-critical"
       enable_alerts: true
       regex: "blazar_tempest_plugin.tests.scenario.test_images.*(?<!non)critical"
     secrets:
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/tacc_prod/
-      name: "CHI@TACC"
+      name: "CHI@TACC-image-noncritical"
       enable_alerts: true
       regex: "blazar_tempest_plugin.tests.scenario.test_images.*noncritical"
     secrets:

--- a/.github/workflows/test_chi_uc_dev.yaml
+++ b/.github/workflows/test_chi_uc_dev.yaml
@@ -3,10 +3,6 @@ name: run smoke tests for DEV@UC
 on: 
   workflow_dispatch:
 
-concurrency:
-  group: "DEV@UC"
-  cancel-in-progress: false
-
 jobs:
   run_tests:
     name: "DEV@UC Smoke Tests"

--- a/.github/workflows/test_chi_uc_prod.yaml
+++ b/.github/workflows/test_chi_uc_prod.yaml
@@ -12,10 +12,6 @@ on:
       - .github/workflows/tempest_action.yaml
       - .github/workflows/test_chi_uc_prod.yaml
 
-concurrency:
-  group: "CHI@UC"
-  cancel-in-progress: false
-
 jobs:
   run_tests:
     name: "CHI@UC Smoke Tests"

--- a/.github/workflows/test_chi_uc_prod_images.yaml
+++ b/.github/workflows/test_chi_uc_prod_images.yaml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/uc_prod/
-      name: "CHI@UC"
+      name: "CHI@UC-image-critical"
       enable_alerts: true
       regex: "blazar_tempest_plugin.tests.scenario.test_images.*(?<!non)critical"
     secrets:
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/uc_prod/
-      name: "CHI@UC"
+      name: "CHI@UC-image-noncritical"
       enable_alerts: true
       regex: "blazar_tempest_plugin.tests.scenario.test_images.*noncritical"
     secrets:

--- a/.github/workflows/test_chi_uc_prod_images.yaml
+++ b/.github/workflows/test_chi_uc_prod_images.yaml
@@ -1,4 +1,4 @@
-name: run non-critical smoke tests for CHI@UC
+name: run image smoke tests for CHI@UC
 
 on:
   workflow_dispatch:
@@ -11,10 +11,6 @@ on:
       - src
       - .github/workflows/tempest_action.yaml
       - .github/workflows/test_chi_uc_prod_noncritical.yaml
-
-concurrency:
-  group: "CHI@UC"
-  cancel-in-progress: false
 
 jobs:
   critical_tests:
@@ -29,7 +25,7 @@ jobs:
       accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
       slack_webhook_url: ${{secrets.slack_webhook_url}}
   noncritical_tests:
-    name: "CHI@UC Smoke Tests (Non-Critical)"
+    name: "CHI@UC Image Tests (Non-Critical)"
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/uc_prod/

--- a/.github/workflows/test_kvm_tacc_prod.yaml
+++ b/.github/workflows/test_kvm_tacc_prod.yaml
@@ -12,10 +12,6 @@ on:
       - .github/workflows/tempest_action.yaml
       - .github/workflows/test_kvm_tacc_prod.yaml
 
-concurrency:
-  group: "KVM@TACC"
-  cancel-in-progress: false
-
 jobs:
   run_tests:
     name: "KVM@TACC Smoke Tests"

--- a/.github/workflows/test_kvm_tacc_prod_images.yaml
+++ b/.github/workflows/test_kvm_tacc_prod_images.yaml
@@ -12,10 +12,6 @@ on:
       - .github/workflows/tempest_action.yaml
       - .github/workflows/test_kvm_tacc_prod_noncritical.yaml
 
-concurrency:
-  group: "KVM@TACC"
-  cancel-in-progress: false
-
 jobs:
   critical_tests:
     name: "KVM@TACC Image Tests"
@@ -29,7 +25,7 @@ jobs:
       accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
       slack_webhook_url: ${{secrets.slack_webhook_url}}
   noncritical_tests:
-    name: "KVM@TACC Image Tests"
+    name: "KVM@TACC Image Tests (Non-Critical)"
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/kvm_prod/

--- a/.github/workflows/test_kvm_tacc_prod_images.yaml
+++ b/.github/workflows/test_kvm_tacc_prod_images.yaml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/kvm_prod/
-      name: "KVM@TACC"
+      name: "KVM@TACC-image-critical"
       enable_alerts: true
       regex: "blazar_tempest_plugin.tests.scenario.test_images.*(?<!non)critical"
     secrets:
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/kvm_prod/
-      name: "KVM@TACC"
+      name: "KVM@TACC-image-noncritical"
       enable_alerts: true
       regex: "blazar_tempest_plugin.tests.scenario.test_images.*noncritical"
     secrets:


### PR DESCRIPTION
we need to ensure all jobs referencing the same site obey concurrency
instead of doing this per workflow, easiest way is to put it into the tempest_action, and key based on the configured site name.

Also address minor nits:
1. output list of tests to run matching regex, if specified
2. fixup names and typos of test cases