### PR TITLE
update build timeout to 40 minutes for baremetal

### DIFF
--- a/reference_configs/nu_prod/tempest.conf
+++ b/reference_configs/nu_prod/tempest.conf
@@ -33,8 +33,8 @@ image_ref_alt = "09cc05d4-f746-4615-8a1b-33a4d47682a2"
 flavor_ref = "668d1cca-d47b-4b70-8b0f-79c7e9ae3341"
 flavor_ref_alt = "668d1cca-d47b-4b70-8b0f-79c7e9ae3341"
 
-# wait up to 15 minutes for node to build
-build_timeout = 900
+# wait up to 40 minutes for node to build and move to ACTIVE
+build_timeout = 2400
 #ready_wait = 0
 
 # used for tests when new network isn't created

--- a/reference_configs/tacc_prod/tempest.conf
+++ b/reference_configs/tacc_prod/tempest.conf
@@ -38,8 +38,8 @@ image_ref_alt = "819473ad-b46c-48db-a2f6-53dead8204b0"
 flavor_ref = "baremetal"
 flavor_ref_alt = "baremetal"
 
-# wait up to 15 minutes for node to build
-build_timeout = 900
+# wait up to 40 minutes for node to build and move to ACTIVE
+build_timeout = 2400
 #ready_wait = 0
 
 # used for tests when new network isn't created

--- a/reference_configs/uc_prod/tempest.conf
+++ b/reference_configs/uc_prod/tempest.conf
@@ -38,8 +38,8 @@ image_ref_alt = "8d72a32d-ced8-461a-8ec9-5b80211f9800"
 flavor_ref = "fc95e5bb-71fb-46a1-b2bc-aaa8eaf4a70a"
 flavor_ref_alt = "fc95e5bb-71fb-46a1-b2bc-aaa8eaf4a70a"
 
-# wait up to 15 minutes for node to build
-build_timeout = 900
+# wait up to 40 minutes for node to build and move to ACTIVE
+build_timeout = 2400
 #ready_wait = 0
 
 # used for tests when new network isn't created


### PR DESCRIPTION
Baremetal nodes can take quite a long time to deploy, as it requires 2 full reboots of a physical node.

In ironic, [deploy_callback_timeout](https://docs.openstack.org/ironic/latest/configuration/config.html#conductor.deploy_callback_timeout) defaults to 1800s, after which deployment will fail with error "timeout waiting ofr call-back".

The end-to-end build timeout is defined in nova, as [instance_build_timeout](https://docs.openstack.org/nova/latest/configuration/config.html#DEFAULT.instance_build_timeout), but is disabled by default.

We set the timeout here to 40 minutes, 2400 seconds, in order to ensure that we catch the ironic timeout error rather than aborting the deployment in the test.