### PR TITLE
workaround image tests canceling due to GH pending

### DIFF
--- a/.github/workflows/test_chi_tacc_prod_images.yaml
+++ b/.github/workflows/test_chi_tacc_prod_images.yaml
@@ -13,25 +13,15 @@ on:
       - .github/workflows/test_chi_tacc_prod_noncritical.yaml
 
 jobs:
-  critical_tests:
+  image_tests:
     name: "CHI@TACC Image Tests"
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/tacc_prod/
       name: "CHI@TACC-image-critical"
       enable_alerts: true
-      regex: "blazar_tempest_plugin.tests.scenario.test_images.*(?<!non)critical"
+      regex: "blazar_tempest_plugin.tests.scenario.test_images"
     secrets:
       accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
-      slack_webhook_url: ${{secrets.slack_webhook_url}}
-  noncritical_tests:
-    name: "CHI@TACC Image Tests (Non-Critical)"
-    uses: ./.github/workflows/tempest_action.yaml
-    with:
-      config-path: reference_configs/tacc_prod/
-      name: "CHI@TACC-image-noncritical"
-      enable_alerts: true
-      regex: "blazar_tempest_plugin.tests.scenario.test_images.*noncritical"
-    secrets:
-      accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
+      # slack_webhook_url: ${{secrets.slack_webhook_url}}
       slack_webhook_url: ${{secrets.slack_noncritical_webhook_url}}

--- a/.github/workflows/test_chi_uc_prod_images.yaml
+++ b/.github/workflows/test_chi_uc_prod_images.yaml
@@ -13,25 +13,15 @@ on:
       - .github/workflows/test_chi_uc_prod_noncritical.yaml
 
 jobs:
-  critical_tests:
+  image_tests:
     name: "CHI@UC Image Tests"
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/uc_prod/
       name: "CHI@UC-image-critical"
       enable_alerts: true
-      regex: "blazar_tempest_plugin.tests.scenario.test_images.*(?<!non)critical"
+      regex: "blazar_tempest_plugin.tests.scenario.test_images"
     secrets:
       accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
-      slack_webhook_url: ${{secrets.slack_webhook_url}}
-  noncritical_tests:
-    name: "CHI@UC Image Tests (Non-Critical)"
-    uses: ./.github/workflows/tempest_action.yaml
-    with:
-      config-path: reference_configs/uc_prod/
-      name: "CHI@UC-image-noncritical"
-      enable_alerts: true
-      regex: "blazar_tempest_plugin.tests.scenario.test_images.*noncritical"
-    secrets:
-      accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
+      # slack_webhook_url: ${{secrets.slack_webhook_url}}
       slack_webhook_url: ${{secrets.slack_noncritical_webhook_url}}

--- a/.github/workflows/test_kvm_tacc_prod_images.yaml
+++ b/.github/workflows/test_kvm_tacc_prod_images.yaml
@@ -13,25 +13,15 @@ on:
       - .github/workflows/test_kvm_tacc_prod_noncritical.yaml
 
 jobs:
-  critical_tests:
+  image_tests:
     name: "KVM@TACC Image Tests"
     uses: ./.github/workflows/tempest_action.yaml
     with:
       config-path: reference_configs/kvm_prod/
       name: "KVM@TACC-image-critical"
       enable_alerts: true
-      regex: "blazar_tempest_plugin.tests.scenario.test_images.*(?<!non)critical"
+      regex: "blazar_tempest_plugin.tests.scenario.test_images"
     secrets:
       accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
-      slack_webhook_url: ${{secrets.slack_webhook_url}}
-  noncritical_tests:
-    name: "KVM@TACC Image Tests (Non-Critical)"
-    uses: ./.github/workflows/tempest_action.yaml
-    with:
-      config-path: reference_configs/kvm_prod/
-      name: "KVM@TACC-image-noncritical"
-      enable_alerts: true
-      regex: "blazar_tempest_plugin.tests.scenario.test_images.*noncritical"
-    secrets:
-      accounts_gpg_passphrase: ${{secrets.accounts_gpg_passphrase}}
+      # slack_webhook_url: ${{secrets.slack_webhook_url}}
       slack_webhook_url: ${{secrets.slack_noncritical_webhook_url}}


### PR DESCRIPTION
github's "concurrency groups" don't work as expected. Unfortunately, pending jobs are canceled instead of queued.
See aurit.pl/github-canceling-since-a-higher-priority-waiting-request-exists/

As a workaround, just run all the image tests in one job, and send all to noncritical alert channel.

Next step for alert routing would be to modify
src/tempest_runner/parse_results.py to generate two output files, filtered by whether tags included noncritical.