### PR TITLE
target self-hosted runners

### DIFF
--- a/.github/workflows/tempest_action.yaml
+++ b/.github/workflows/tempest_action.yaml
@@ -29,7 +29,7 @@ jobs:
       group: ${{inputs.config-path}}
       cancel-in-progress: false
     name: "Tempest Tests: ${{inputs.name}}"
-    runs-on: ubuntu-22.04
+    runs-on: [self-hosted, ubuntu-24.04]
     env:
       artifact_name: "${{inputs.name}}-ctrf-report"
     steps:

--- a/.github/workflows/tempest_action.yaml
+++ b/.github/workflows/tempest_action.yaml
@@ -47,10 +47,14 @@ jobs:
           ./decrypt_secret.sh \
             "${{inputs.config-path}}/accounts.yaml.gpg" \
             "${{inputs.config-path}}/accounts.yaml"
+      - name: delete any conflicting workspace folder
+        run: |
+          rm -rf workspace && mkdir workspace
       - name: init workspace
         run: |
           tempest init \
           --config-dir ${{inputs.config-path}} \
+          --workspace-path workspace/workspace.yaml \
           --name ${{inputs.name}} \
           workspace
       - name: show templated config


### PR DESCRIPTION
A self-hosted runner is now registered, running on KVM@TACC.

This should make the chi@edge tests pass, as ping will work. It also avoids us running out of "free credits".

Caveats:
* on persistent runners, workspace is not cleared between runs
* if instance goes down, the smoke tests will stop running. GH won't let you "prefer self-hosted if available, GH otherwise"
* only 1 job at a time per runner

The "best practice" would be to set up a webhook which would launch+register an ephemeral runner on KVM, but that's more work than we want right now.