### PR TITLE
Use medium instead of small flavors for kvm image tests

### DIFF
--- a/reference_configs/kvm_prod/tempest.conf
+++ b/reference_configs/kvm_prod/tempest.conf
@@ -69,7 +69,7 @@ ipv6 = false
 dashboard_url = https://kvm.tacc.chameleoncloud.org
 
 [reservation]
-reservable_flavor_ref = "m1.small"
+reservable_flavor_ref = "m1.medium"
 reservation_type = kvm
 
 [reservation-feature-enabled]


### PR DESCRIPTION
The CUDA images are slightly too big for the 20GB disk size of small.