### PR TITLE
Updating CHI@NCAR test images

### DIFF
--- a/reference_configs/ncar_prod/tempest.conf
+++ b/reference_configs/ncar_prod/tempest.conf
@@ -30,11 +30,11 @@ zun = false
 [compute]
 
 
-#CC-Ubuntu22.04
-image_ref = "d43f5148-46ba-48a5-8908-a90f8951ce52"
+#CC-Ubuntu24.04-AMD64
+image_ref = "5ad70b07-372e-459e-ba58-a8bd5501090b"
 
-#CC-Ubuntu20.04
-image_ref_alt = "0d499783-262a-4342-aa6d-1788c4eef8c5"
+#CC-Ubuntu22.04-ARM
+image_ref_alt = "d43f5148-46ba-48a5-8908-a90f8951ce52"
 
 # baremetal flavor id
 # for baremetal, list it twice

--- a/reference_configs/ncar_prod/tempest.conf
+++ b/reference_configs/ncar_prod/tempest.conf
@@ -18,7 +18,7 @@ v3_endpoint_type = public
 
 [service_available]
 cinder = false
-swift = true
+swift = false
 blazar = true
 zun = false
 

--- a/reference_configs/ncar_prod/tempest.conf
+++ b/reference_configs/ncar_prod/tempest.conf
@@ -33,8 +33,8 @@ zun = false
 #CC-Ubuntu24.04-AMD64
 image_ref = "5ad70b07-372e-459e-ba58-a8bd5501090b"
 
-#CC-Ubuntu22.04-ARM
-image_ref_alt = "d43f5148-46ba-48a5-8908-a90f8951ce52"
+#CC-Ubuntu24.04-AMD64
+image_ref_alt = "5ad70b07-372e-459e-ba58-a8bd5501090b"
 
 # baremetal flavor id
 # for baremetal, list it twice


### PR DESCRIPTION
Changed image_ref to Ubuntu 24 AMD64 image for new nodes. Changed image_ref_alt to the Ubuntu 22 ARM image for tharm nodes in the future.